### PR TITLE
Modernize MetaInfo

### DIFF
--- a/org.mesa3d.vaapi.freeworld.metainfo.xml
+++ b/org.mesa3d.vaapi.freeworld.metainfo.xml
@@ -5,10 +5,10 @@
   <summary>Video Acceleration API Driver</summary>
   <description>
     <p>
-      The Mesa VA-API (Video Acceleration API)
-      user mode driver brings hardware accelerated decoding, encoding,
-      and video post processing for AMD graphics processing units and NVIDIA 
-      counterpart running on Nouveau driver. The drive provides support for H264, AVC  and VC-1.
+      The Mesa VA-API State Tracker (Video Acceleration API)
+      user mode driver brings hardware accelerated decoding, encoding implementation on
+      and video post processing for Gallium AMD drivers and for NVIDIA counterpart running on Nouveau Gallium driver. 
+      This driver provides support for H264, H265 and VC-1.
     </p>
   </description>
   <translation/>

--- a/org.mesa3d.vaapi.freeworld.metainfo.xml
+++ b/org.mesa3d.vaapi.freeworld.metainfo.xml
@@ -7,7 +7,7 @@
     <p>
       The Mesa VA-API State Tracker (Video Acceleration API)
       user mode driver brings hardware accelerated decoding, encoding implementation on
-      and video post processing for Gallium AMD drivers and for NVIDIA counterpart running on Nouveau Gallium driver. 
+      and video post processing for Gallium AMD drivers.
       This driver provides support for H264, H265 and VC-1.
     </p>
   </description>

--- a/org.mesa3d.vdpau.freeworld.metainfo.xml
+++ b/org.mesa3d.vdpau.freeworld.metainfo.xml
@@ -6,9 +6,10 @@
   <summary>Accelerated Linux Graphics Driver</summary>
   <description>
     <p>
-      The Mesa VA-API (Video Decode and Presentation API for UNIX)
-      user mode driver provides an interface to video decode acceleration and           presentation hardware present in AMD graphics processing units and NVIDIA 
-      counterpart running on Nouveau driver. The drive provides support for H264, AVC  and VC-1.
+      The Mesa VDPAU State Tracker (Video Decode and Presentation API for UNIX DRIVER)
+      user mode driver brings hardware accelerated decoding, encoding implementation and
+      presentation API for Gallium AMD drivers and for NVIDIA counterpart running on Nouveau Gallium driver. 
+      This driver provides support for H264, H265 and VC-1.
     </p>
   </description>
   <translation/>


### PR DESCRIPTION
Mesa3D uses Gallium Driver architecture for multi vendors GPUs Driver.
Gallium for default uses State Trackers (Gallium Frontends) For implement API in Gallium API.
For default a VDPAU and VA-API are State Trackers for Gallium.
Nvidia can't support VA-API don't have reason to maintain this in VAAPI metainfo