### PR TITLE
radeonsi: disallow compute queues on Raven/Raven2 due to hangs.

### DIFF
--- a/mesa-24.3.4-radeonsi-disallow-compute-queues-on-Raven_Raven2-due-to-hangs.patch
+++ b/mesa-24.3.4-radeonsi-disallow-compute-queues-on-Raven_Raven2-due-to-hangs.patch
@@ -1,0 +1,37 @@
+From 3b78dcec058e85321f636f353ad5c23c986e3a11 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Ol=C5=A1=C3=A1k?= <marek.olsak@amd.com>
+Date: Mon, 27 Jan 2025 15:24:21 -0500
+Subject: [PATCH] radeonsi: disallow compute queues on Raven/Raven2 due to
+ hangs
+
+Fixes: 58b512ddd6e - radeonsi: execute clears at resource allocation using compute instead of gfx
+Closes: https://gitlab.freedesktop.org/mesa/mesa/-/issues/12310
+
+Reviewed-by: Pierre-Eric Pelloux-Prayer <pierre-eric.pelloux-prayer@amd.com>
+Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/33248>
+---
+ src/gallium/drivers/radeonsi/si_pipe.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/src/gallium/drivers/radeonsi/si_pipe.c b/src/gallium/drivers/radeonsi/si_pipe.c
+index 52ac2fc3eaded..38b45e5d356c9 100644
+--- a/src/gallium/drivers/radeonsi/si_pipe.c
++++ b/src/gallium/drivers/radeonsi/si_pipe.c
+@@ -517,7 +517,13 @@ static struct pipe_context *si_create_context(struct pipe_screen *screen, unsign
+       return NULL;
+    }
+ 
+-   sctx->has_graphics = sscreen->info.gfx_level == GFX6 || !(flags & PIPE_CONTEXT_COMPUTE_ONLY);
++   sctx->has_graphics = sscreen->info.gfx_level == GFX6 ||
++                        /* Compute queues hang on Raven and derivatives, see:
++                         * https://gitlab.freedesktop.org/mesa/mesa/-/issues/12310 */
++                        ((sscreen->info.family == CHIP_RAVEN ||
++                          sscreen->info.family == CHIP_RAVEN2) &&
++                         !sscreen->info.has_dedicated_vram) ||
++                        !(flags & PIPE_CONTEXT_COMPUTE_ONLY);
+ 
+    if (flags & PIPE_CONTEXT_DEBUG)
+       sscreen->record_llvm_ir = true; /* racy but not critical */
+-- 
+GitLab
+

--- a/mesa-freeworld.spec
+++ b/mesa-freeworld.spec
@@ -72,7 +72,7 @@ Name:           %{srcname}-freeworld
 Summary:        Mesa graphics libraries
 %global ver 24.3.4
 Version:        %{lua:ver = string.gsub(rpm.expand("%{ver}"), "-", "~"); print(ver)}
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        MIT AND BSD-3-Clause AND SGI-B-2.0
 URL:            http://www.mesa3d.org
 
@@ -83,6 +83,10 @@ Source0:        https://archive.mesa3d.org/%{srcname}-%{ver}.tar.xz
 Source1:        Mesa-MLAA-License-Clarification-Email.txt
 Source2:        org.mesa3d.vaapi.freeworld.metainfo.xml
 Source3:        org.mesa3d.vdpau.freeworld.metainfo.xml
+
+# https://gitlab.freedesktop.org/mesa/mesa/-/issues/12310
+# https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/33248
+Patch12:        https://gitlab.freedesktop.org/mesa/mesa/-/commit/3b78dcec058e.patch#/mesa-24.3.4-radeonsi-disallow-compute-queues-on-Raven_Raven2-due-to-hangs.patch
 
 BuildRequires:  meson >= 1.3.0
 BuildRequires:  gcc
@@ -353,6 +357,10 @@ echo -e "%{_libdir}/dri-freeworld/ \n" > %{buildroot}%{_sysconfdir}/ld.so.conf.d
 %endif
 
 %changelog
+* Tue Jan 28 2025 Björn Esser <besser82@fedoraproject.org> - 24.3.4-8
+- Add patch for radeonsi to disallow compute queues on Raven/Raven2
+  due to hangs
+
 * Mon Jan 27 2025 Thorsten Leemhuis <fedora@leemhuis.info> - 24.3.4-7
 - Drop conflicts with mesa-va-drivers, as its files do not conclict
   anymore with the ones in mesa-va-drivers-freeworld


### PR DESCRIPTION
See: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/33248
and: https://gitlab.freedesktop.org/mesa/mesa/-/issues/12310

Fedora PR: https://src.fedoraproject.org/rpms/mesa/pull-request/60

***

This also affects F41.