### PR TITLE
Fix general installability of mesa-vulkan-drivers-freeworld.

### DIFF
--- a/mesa-freeworld.spec
+++ b/mesa-freeworld.spec
@@ -72,7 +72,7 @@ Name:           %{srcname}-freeworld
 Summary:        Mesa graphics libraries
 %global ver 25.0.0
 Version:        %{lua:ver = string.gsub(rpm.expand("%{ver}"), "-", "~"); print(ver)}
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT AND BSD-3-Clause AND SGI-B-2.0
 URL:            http://www.mesa3d.org
 
@@ -205,7 +205,9 @@ Conflicts:      %{srcname}-vdpau-drivers%{?_isa}
 %package -n %{srcname}-vulkan-drivers-freeworld
 Summary:        Mesa Vulkan drivers
 Requires:       vulkan%{_isa}
-Requires:       %{srcname}-vulkan-drivers%{?_isa} = %{?epoch:%{epoch}:}%{version}
+Requires:       %{name}-filesystem%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+Provides:       %{srcname}-vulkan-drivers%{?_isa} = %{?epoch:%{epoch}:}%{version}
+Obsoletes:      mesa-vulkan-devel < %{?epoch:%{epoch}:}%{version}-%{release}
 # the following conflict is needed until we can find a way to install freeworld
 # drivers in parallel to Fedora's; for ideas how to realize this see:
 # * https://github.com/KhronosGroup/Vulkan-Loader/issues/1647 and its backstory: 
@@ -416,6 +418,9 @@ echo -e "%{_libdir}/dri-freeworld/ \n" > %{buildroot}%{_sysconfdir}/ld.so.conf.d
 %endif
 
 %changelog
+* Thu Feb 20 2025 Björn Esser <besser82@fedoraproject.org> - 25.0.0-2
+- Fix general installability of mesa-vulkan-drivers-freeworld
+
 * Wed Feb 19 2025 Thorsten Leemhuis <fedora@leemhuis.info> - 25.0.0-1
 - Update to 25.0.0
 - add 0001-vulkan-wsi-x11-fix-use-of-uninitialised-xfixes-regio.patch


### PR DESCRIPTION
Requires / Provides / Obsoletes are taken from Fedora mesa package.